### PR TITLE
pintool: Fix GCC 11 compilation

### DIFF
--- a/pintool/addrtrace.cpp
+++ b/pintool/addrtrace.cpp
@@ -899,11 +899,14 @@ VOID ThreadStart(THREADID threadid, CONTEXT *ctxt, INT32 flags, VOID *v)
     //PIN_MutexLock(&lock);
     if (thread_state.size() <= threadid) {
       thread_state_t newstate;
+      newstate.RetIP = 0;
+      newstate.newbbl = 0;
       thread_state.push_back(newstate);
+    } else {
+      thread_state[threadid].RetIP = 0;
+      thread_state[threadid].newbbl = 0;
     }
     ASSERT(thread_state.size() > threadid, "[pintool] Error: thread_state corrupted");
-    thread_state[threadid].RetIP = 0;
-    thread_state[threadid].newbbl = 0;
     //PIN_MutexUnlock(&lock);
 }
 


### PR DESCRIPTION
GCC 11.2.1 emits a ``maybe-uninitialized`` warning because a partially initialised
class instance is pushed to a vector. The missing class members are initialised
right after, yielding correct behaviour despite the warning. Ensure the class
instance is fully initialised before pushing it to the vector to silence the
warning.

Compiler warning for reference:
```
In copy constructor ‘thread_state_t::thread_state_t(const thread_state_t&)’,
    inlined from ‘void std::_Copy_Construct_aux(_Tp*, const _Tp&, const std::__false_type&) [with _Tp = thread_state_t]’ at /home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/pin/pin-3.11-97998-g7ecce2dac-gcc-linux/extras/stlport/include/stl/_construct.h:119:3,
    inlined from ‘void std::_Copy_Construct(_Tp*, const _Tp&) [with _Tp = thread_state_t]’ at /home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/pin/pin-3.11-97998-g7ecce2dac-gcc-linux/extras/stlport/include/stl/_construct.h:134:22,
    inlined from ‘void std::vector<_Tp, _Alloc>::push_back(const _Tp&) [with _Tp = thread_state_t; _Alloc = std::allocator<thread_state_t>]’ at /home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/pin/pin-3.11-97998-g7ecce2dac-gcc-linux/extras/stlport/include/stl/_vector.h:396:22,
    inlined from ‘VOID ThreadStart(LEVEL_VM::THREADID, LEVEL_VM::CONTEXT*, INT32, VOID*)’ at addrtrace.cpp:902:29:
addrtrace.cpp:224:3: error: ‘newstate.thread_state_t::RetIP’ may be used uninitialized [-Werror=maybe-uninitialized]
  224 | } thread_state_t;
      |   ^~~~~~~~~~~~~~
addrtrace.cpp: In function ‘VOID ThreadStart(LEVEL_VM::THREADID, LEVEL_VM::CONTEXT*, INT32, VOID*)’:
addrtrace.cpp:901:22: note: ‘newstate’ declared here
  901 |       thread_state_t newstate;
      |                      ^~~~~~~~
In copy constructor ‘thread_state_t::thread_state_t(const thread_state_t&)’,
    inlined from ‘void std::_Copy_Construct_aux(_Tp*, const _Tp&, const std::__false_type&) [with _Tp = thread_state_t]’ at /home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/pin/pin-3.11-97998-g7ecce2dac-gcc-linux/extras/stlport/include/stl/_construct.h:119:3,
    inlined from ‘void std::_Copy_Construct(_Tp*, const _Tp&) [with _Tp = thread_state_t]’ at /home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/pin/pin-3.11-97998-g7ecce2dac-gcc-linux/extras/stlport/include/stl/_construct.h:134:22,
    inlined from ‘void std::vector<_Tp, _Alloc>::push_back(const _Tp&) [with _Tp = thread_state_t; _Alloc = std::allocator<thread_state_t>]’ at /home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/pin/pin-3.11-97998-g7ecce2dac-gcc-linux/extras/stlport/include/stl/_vector.h:396:22,
    inlined from ‘VOID ThreadStart(LEVEL_VM::THREADID, LEVEL_VM::CONTEXT*, INT32, VOID*)’ at addrtrace.cpp:902:29:
addrtrace.cpp:224:3: error: ‘newstate.thread_state_t::newbbl’ may be used uninitialized [-Werror=maybe-uninitialized]
  224 | } thread_state_t;
      |   ^~~~~~~~~~~~~~
addrtrace.cpp: In function ‘VOID ThreadStart(LEVEL_VM::THREADID, LEVEL_VM::CONTEXT*, INT32, VOID*)’:
addrtrace.cpp:901:22: note: ‘newstate’ declared here
  901 |       thread_state_t newstate;
      |                      ^~~~~~~~
```