### PR TITLE
fix: use builtin types over removed numpy aliases

### DIFF
--- a/analysis/analyze.py
+++ b/analysis/analyze.py
@@ -844,7 +844,7 @@ def specific_leakage_test(random, callback, LeaksOnly=True, mp=False):
 
         # postprocessing -- type3
         for c in rdic_pos.keys():
-            rdic_pos[c] = numpy.array(rdic_pos[c], dtype=numpy.int)
+            rdic_pos[c] = numpy.array(rdic_pos[c], dtype=int)
 
         # Extract X in correct order
         X = numpy.asarray([Xglob[k] for k in keys])

--- a/analysis/rdctest.py
+++ b/analysis/rdctest.py
@@ -236,7 +236,7 @@ class RDC(object):
 
         # compute sigthres level
         l = 10000
-        v = numpy.zeros(l, dtype=numpy.float)
+        v = numpy.zeros(l, dtype=float)
         for i in range(0, l):
             a = numpy.random.normal(size=N)
             b = numpy.random.normal(size=N)
@@ -360,10 +360,10 @@ class RDC(object):
 
         # init
         (n1, n2) = (X.size, Y.size)
-        t1 = numpy.ones((n1,2), dtype=numpy.float)
-        t2 = numpy.ones((n2,2), dtype=numpy.float)
-        t3 = numpy.ones((n1,k+1), dtype=numpy.float)
-        t4 = numpy.ones((n2,k+1), dtype=numpy.float)
+        t1 = numpy.ones((n1,2), dtype=float)
+        t2 = numpy.ones((n2,2), dtype=float)
+        t3 = numpy.ones((n1,k+1), dtype=float)
+        t4 = numpy.ones((n2,k+1), dtype=float)
 
         # normalized rank
         t1[:,0] = rankdata(X) / float(n1)


### PR DESCRIPTION
Numpy 1.20 (released Jan 30, 2021) [deprecated the `numpy.{int,float,...}` aliases](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) and numpy 1.24 (released Dec 18, 2022) [removed these aliases](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).

This PR replaces uses of `numpy.int` with `int` and `numpy.float` with `float`. For me, numpy 2.1.3 was installed in the pyenv (Python 3.12, Ubuntu 24.04). This lead to errors when running phase 2 and 3.

---

Aside: One error I got when using the data-gui was that `QColor(h, s, l, a)` doesn't allow floats for HSL.

<details><summary>Patch</summary>

```diff
diff --git a/datagui/package/utils.py b/datagui/package/utils.py
index 020bd28..50c3092 100644
--- a/datagui/package/utils.py
+++ b/datagui/package/utils.py
@@ -380,7 +380,7 @@ def getColor(value, threshold):
     lightness = 100
     # alpha = 255 * (1 - threshold)
     color = QColor()
-    color.setHsl(hue, saturation, lightness, 255)
+    color.setHsl(int(hue), int(saturation), int(lightness), 255)
     return color
 
 def createIconButton(size, flag_id):
```
</details> 